### PR TITLE
Fix S3 generic/method consistency

### DIFF
--- a/err-constructor.Rmd
+++ b/err-constructor.Rmd
@@ -65,8 +65,8 @@ To generate the error message shown to the user, provide a `conditionMessage()` 
 
 ```{r}
 #' @export
-conditionMessage.fs_error_not_found <- function(cnd) {
-  glue::glue_data(cnd, "'{path}' not found")
+conditionMessage.fs_error_not_found <- function(c) {
+  glue::glue_data(c, "'{path}' not found")
 }
 ```
 


### PR DESCRIPTION
I was trying to follow the pattern of creating custom error conditions, but saw R CMD check warnings about S3 generic/method consistency. This change should fix that.